### PR TITLE
Fix: SIVT hangs when Avi is not reachable

### DIFF
--- a/src/common/common_utilities.py
+++ b/src/common/common_utilities.py
@@ -7199,7 +7199,7 @@ def getAviIpFqdnDnsMapping(avi_controller_fqdn_ip_dict, dns_server):
     try:
         for dns in dns_server:
             for avi_fqdn, avi_ip in avi_controller_fqdn_ip_dict.items():
-                listOfCmd = ["dig", dns, avi_fqdn, "+short"]
+                listOfCmd = ["dig", f"@{dns}", avi_fqdn, "+short"]
                 fqdn_ip_map = runShellCommandAndReturnOutputAsList(listOfCmd)
                 current_app.logger.info(fqdn_ip_map)
                 for ip in fqdn_ip_map[0]:

--- a/src/common/common_utilities.py
+++ b/src/common/common_utilities.py
@@ -7237,7 +7237,8 @@ def getAviIpFqdnDnsMapping(avi_controller_fqdn_ip_dict, dns_server):
                     if not ip and not str(ip).__contains__(avi_ip):
                         return "DNS Entry not found for : " + avi_fqdn , 500
                     else:
-                        current_app.logger.info("Found DNS entry for " + avi_fqdn + " : " + ip)
+                        replace_urllib3_create_connection(dns)
+                        current_app.logger.debug("NOTE: urllib3 is now using custom DNS server: " + dns)
                         # avi_controller_fqdn_ip_dict.pop(avi_fqdn)
         return "Successfully validated NSX ALB Fqdn and Ip entry on DNS Server", 200
     except:

--- a/src/common/prechecks/precheck.py
+++ b/src/common/prechecks/precheck.py
@@ -7,6 +7,7 @@ import sys
 import tarfile
 import time
 import logging
+import yaml
 from flask import jsonify, request
 from flask import Flask
 import requests
@@ -172,7 +173,10 @@ def tkgm_management_cluster_already_exists():
         return env_type == 'tkgm'
 
     def management_cluster_in_tanzu_config(cluster):
-        fp = os.path.join(os.environ['HOME'], ".config", "tanzu", "config.yaml")
+        home_dir = '/root'
+        if 'HOME' in os.environ:
+            home_dir = os.environ['HOME']
+        fp = os.path.join(home_dir, ".config", "tanzu", "config.yaml")
         if not os.path.exists(fp):
             current_app.logger.debug(f"Tanzu config not written yet to {fp}; stopping check")
             return False
@@ -181,6 +185,10 @@ def tkgm_management_cluster_already_exists():
         if data == '':
             current_app.logger.debug(f"No data in Tanzu config '{fp}'; stopping check")
             return False
+        if 'servers' not in data:
+            current_app.logger.debug(f"This Tanzu config does not have any servers in it: {fp}")
+            return False
+        current_app.logger.debug(f"Data: {str(data)}")
         clusters_in_config = [ server.name for server in data['servers'] ]
         return (cluster in clusters_in_config)
 

--- a/src/common/prechecks/precheck.py
+++ b/src/common/prechecks/precheck.py
@@ -1013,8 +1013,14 @@ def validateToken(token, serviceList):
                 "msg": serviceList[0] + " login failed using Refresh_Token ",
                 "ERROR_CODE": 500
             }
-            current_app.logger.error(serviceList[0] + " login failed using Refresh_Token - %s" % token)
-            return 500
+            body = json.dumps(response_login)
+            if 'message' in body:
+                error = body['message']
+            else:
+                error = 'unknown error'
+            current_app.logger.error(serviceList[0] + " login failed using Refresh_Token - %s: %s" %
+                    token, error)
+            return error, 500
         access_token = response_login.json()["access_token"]
 
         url = "https://console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/details"

--- a/src/vsphere/managementConfig/vsphere_management_config.py
+++ b/src/vsphere/managementConfig/vsphere_management_config.py
@@ -103,6 +103,7 @@ def configCloud():
     cluster_name = current_app.config['VC_CLUSTER']
     data_center = current_app.config['VC_DATACENTER']
     data_store = current_app.config['VC_DATASTORE']
+    dns_servers_csv = request.get_json(force=True)['envSpec']['infraComponents']['dnsServersIp']
     req = True
     refToken = request.get_json(force=True)['envSpec']['marketplaceSpec']['refreshToken']
     if refToken and (env == Env.VSPHERE or env == Env.VCF):
@@ -2208,6 +2209,7 @@ def templateMgmtDeployYaml(ip, datacenter, data_store, cluster_name, wpName, wip
                            vcenter_username,
                            password, env, vsSpec):
     deploy_yaml = FileHelper.read_resource(Paths.TKG_MGMT_SPEC_J2)
+    dns_servers_csv = request.get_json(force=True)['envSpec']['infraComponents']['dnsServersIp']
     t = Template(deploy_yaml)
     datastore_path = "/" + datacenter + "/datastore/" + data_store
     vsphere_folder_path = "/" + datacenter + "/vm/" + ResourcePoolAndFolderName.TKG_Mgmt_Components_Folder_VSPHERE
@@ -2295,7 +2297,7 @@ def templateMgmtDeployYaml(ip, datacenter, data_store, cluster_name, wpName, wip
                 oidc_provider_username_claim = str(
                     request.get_json(force=True)["tkgComponentSpec"]["identityManagementSpec"]["oidcSpec"]["oidcUsernameClaim"])
                 FileHelper.write_to_file(
-                    t.render(config=vsSpec, avi_cert=get_base64_cert(ip), ip=ip, wpName=wpName, wipIpNetmask=wipIpNetmask,
+                    t.render(config=vsSpec, avi_cert=get_base64_cert(ip, dns_servers_csv=dns_servers_csv), ip=ip, wpName=wpName, wipIpNetmask=wipIpNetmask,
                              avi_label_key=AkoType.KEY, avi_label_value=AkoType.VALUE, cluster_name=management_cluster,
                              data_center=datacenter, datastore_path=datastore_path,
                              vsphere_folder_path=vsphere_folder_path, vcenter_passwd=vcenter_passwd, vsphere_rp=vsphere_rp,
@@ -2360,7 +2362,7 @@ def templateMgmtDeployYaml(ip, datacenter, data_store, cluster_name, wpName, wip
                 base64_bytes = base64.b64encode(ldap_root_ca_data.encode("utf-8"))
                 ldap_root_ca_data_base64 = str(base64_bytes, "utf-8")
                 FileHelper.write_to_file(
-                    t.render(config=vsSpec, avi_cert=get_base64_cert(ip), ip=ip, wpName=wpName, wipIpNetmask=wipIpNetmask,
+                    t.render(config=vsSpec, avi_cert=get_base64_cert(ip, dns_servers_csv=dns_servers_csv), ip=ip, wpName=wpName, wipIpNetmask=wipIpNetmask,
                              avi_label_key=AkoType.KEY, avi_label_value=AkoType.VALUE, cluster_name=management_cluster,
                              data_center=datacenter, datastore_path=datastore_path,
                              vsphere_folder_path=vsphere_folder_path, vcenter_passwd=vcenter_passwd, vsphere_rp=vsphere_rp,
@@ -2386,7 +2388,7 @@ def templateMgmtDeployYaml(ip, datacenter, data_store, cluster_name, wpName, wip
             raise Exception("Keyword " + str(e) + "  not found in input file")
     else:
         FileHelper.write_to_file(
-            t.render(config=vsSpec, avi_cert=get_base64_cert(ip), ip=ip, wpName=wpName, wipIpNetmask=wipIpNetmask,
+            t.render(config=vsSpec, avi_cert=get_base64_cert(ip, dns_servers_csv=dns_servers_csv), ip=ip, wpName=wpName, wipIpNetmask=wipIpNetmask,
                      avi_label_key=AkoType.KEY, avi_label_value=AkoType.VALUE, cluster_name=management_cluster,
                      data_center=datacenter, datastore_path=datastore_path,
                      vsphere_folder_path=vsphere_folder_path, vcenter_passwd=vcenter_passwd, vsphere_rp=vsphere_rp,


### PR DESCRIPTION
If an Avi node is not reachable at port 443, `arcas` will hang "waiting" for it to come up.

This fix front-loads this by making sure the IP address we're hitting is serving HTTPS.
